### PR TITLE
LPS-177122 DDTemplate.name column has LOB type. In order to be used i…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/DDMTemplateNameComparator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/DDMTemplateNameComparator.java
@@ -29,9 +29,11 @@ import java.util.Locale;
  */
 public class DDMTemplateNameComparator extends OrderByComparator<DDMTemplate> {
 
-	public static final String ORDER_BY_ASC = "DDMTemplate.name ASC";
+	public static final String ORDER_BY_ASC =
+		"CAST_CLOB_TEXT(DDMTemplate.name) ASC";
 
-	public static final String ORDER_BY_DESC = "DDMTemplate.name DESC";
+	public static final String ORDER_BY_DESC =
+		"CAST_CLOB_TEXT(DDMTemplate.name) DESC";
 
 	public static final String[] ORDER_BY_FIELDS = {"name"};
 


### PR DESCRIPTION
…n a 'group by' clause (i.e. Oracle and DB2 databases), it needs to be coverted to VARCHAR.